### PR TITLE
allow options to be passed to the script

### DIFF
--- a/pinentry-wsl-ps1.sh
+++ b/pinentry-wsl-ps1.sh
@@ -31,9 +31,9 @@
 #    with every usage.
 #    * Disable: edit the script, near the top, set NOTIFY to the value "0"
 #    * Enable: edit the script, near the top, set NOTIFY to the value "1"
-PERSISTENCE=""
-NOTIFY="1"
-DEBUGLOG=""
+PERSISTENCE=${PERSISTENCE:-""}
+NOTIFY=${NOTIFY:-"1"}
+DEBUGLOG=${DEBUGLOG:-""}
 
 # Do not casually edit the below values
 VERSION="0.2.1"

--- a/pinentry-wsl-ps1.sh
+++ b/pinentry-wsl-ps1.sh
@@ -31,9 +31,9 @@
 #    with every usage.
 #    * Disable: edit the script, near the top, set NOTIFY to the value "0"
 #    * Enable: edit the script, near the top, set NOTIFY to the value "1"
-PERSISTENCE=${PERSISTENCE:-""}
-NOTIFY=${NOTIFY:-"1"}
-DEBUGLOG=${DEBUGLOG:-""}
+PERSISTENCE=${PERSISTENCE-""}
+NOTIFY=${NOTIFY-"1"}
+DEBUGLOG=${DEBUGLOG-""}
 
 # Do not casually edit the below values
 VERSION="0.2.1"


### PR DESCRIPTION
This way, options can be set by, say `NOTIFY=0 pinentry-wsl-ps1.sh`; thus the script can be updated without losing once set options.