### PR TITLE
Bug fix: Allow backslashes (\) in passwords

### DIFF
--- a/pinentry-wsl-ps1.sh
+++ b/pinentry-wsl-ps1.sh
@@ -154,7 +154,7 @@ DLM
                 if [ -n "$KEYINFO" ]; then
                     credpassword="$(powershell.exe -nologo -noprofile -noninteractive -command "$cmd_lookup")"
                     if [ -n "$credpassword" ]; then
-                        echo -e "S PASSWORD_FROM_CACHE\nD $credpassword\nOK"
+                        printf "S PASSWORD_FROM_CACHE\nD %s\nOK\n" "$credpassword"
                         if [ "$NOTIFY" == "1" ]; then
                             powershell.exe -nologo -noprofile -noninteractive -command "$cmd_toast" > /dev/null
                         fi
@@ -170,20 +170,20 @@ DLM
         if [ "$REPEATPASSWORD" == "1" ]; then
             credpasswordrepeat="$(powershell.exe -nologo -noprofile -noninteractive -command "$cmd_repeat")"
             if [ "$credpassword" == "$credpasswordrepeat" ]; then
-                echo -e "S PIN_REPEATED\nD $credpassword\nOK"
+                printf "S PIN_REPEATED\nD %s\nOK\n" "$credpassword"
             else
                 message "$REPEATERROR" > /dev/null
                 echo "$(assuan_result 114)" # unsure this is the correct error
                 return
             fi
         else
-            echo -e "D $credpassword\nOK"
+	    printf "D %s\nOK\n" "$credpassword"
         fi
         if [ "$EXTPASSCACHE" == "1" ]; then
             if [ -n "$KEYINFO" ]; then
                 # avoid setting password on visible param
                 # alt is to always save on the single or last-of-repeat dialog. And if the repeat fails, then immediately delete it from the cred store
-                builtin echo -n "$credpassword" | powershell.exe -nologo -noprofile -noninteractive -command "$cmd_store"
+                builtin echo -n -E "$credpassword" | powershell.exe -nologo -noprofile -noninteractive -command "$cmd_store"
             fi
         fi
     else


### PR DESCRIPTION
`echo -e` by definition enables the interpretation of backslash escapes. This was to allow to use of `\n` within the `echo` commands.

The downside to this is any backslashes within the `$credpassword` variable also get interpreted corrupting the password.

This change allows backslashes to be used within the `$credpassword` variable.