### PR TITLE
propose exporting $PINENTRY_BINARY

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Licensed under the Mozilla Public License 2.0
      `pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh`
     2. Or, set the path to this script when you launch gpg-agent, e.g.  
      `gpg-agent --pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh`
+    3. Or, set `$PINENTRY_BINARY` to the path of this script in `~/.profile` (see below) on supporting
+       distributions such as [Opensuse](https://obs.smar.fi/package/view_file/SUSE:SLE-15:Update/pinentry/pinentry?expand=0)
 3. Optionally _enable_ persistence of passwords.  
     1. Follow instructions <https://github.com/davotronic5000/PowerShell_Credential_Manager>
    to install the needed module from the Powershell Gallery or GitHub.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ Licensed under the Mozilla Public License 2.0
      `pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh`
     2. Or, set the path to this script when you launch gpg-agent, e.g.  
      `gpg-agent --pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh`
-    3. Or, set `$PINENTRY_BINARY` to the path of this script in `~/.profile` (see below) on supporting
-       distributions such as [Opensuse](https://obs.smar.fi/package/view_file/SUSE:SLE-15:Update/pinentry/pinentry?expand=0)
+    3. Or, more portable, set pinentry-program within ~/.gnupg/gpg-agent.conf to a [custom pin-entry script](https://a3nm.net/git/mybin/file/my-pinentry.html) 
+       checking for a case `wsl); exec /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh "$@";;`, and 
+       add the line `[ -z ${WSLENV+x} ] || PINENTRY_USER_DATA=wsl` to `~/.profile`
+    4. Or,  on supporting distributions (such as [Opensuse](https://obs.smar.fi/package/view_file/SUSE:SLE-15:Update/pinentry/pinentry?expand=0)),
+       add `[ -z ${WSLENV+x} ] || PINENTRY_BINARY=/mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh` in `~/.profile`
 3. Optionally _enable_ persistence of passwords.  
     1. Follow instructions <https://github.com/davotronic5000/PowerShell_Credential_Manager>
    to install the needed module from the Powershell Gallery or GitHub.


### PR DESCRIPTION
This is an alternative to setting GPG's pinentry-program where available.

Allows for a `~/.profile` that works on Linux and WSL by

```sh
[ -z ${WSLENV+x} ] || export PINENTRY_BINARY="$HOME/bin/pinentry-wsl-ps1.sh"
```
