### PR TITLE
Modify instructions to use update-alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ Licensed under the Mozilla Public License 2.0
    `chmod ug=rx pinentry-wsl-ps1.sh`
 2. Configure gpg-agent to use this script for pinentry using
    one of the following methods  
-    1. Set pinentry-program within ~/.gnupg/gpg-agent.conf to the script's path, e.g.  
+    1. Use `update-alternatives` to change the symlink in `/usr/bin/pinentry`
+    ```
+    sudo update-alternatives --install /usr/bin/pinentry pinentry /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh 10
+    sudo update-alternatives --set pinentry /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh
+    ```
+    2. Set pinentry-program within ~/.gnupg/gpg-agent.conf to the script's path, e.g.  
      `pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh`
-    2. Or, set the path to this script when you launch gpg-agent, e.g.  
+    3. Or, set the path to this script when you launch gpg-agent, e.g.  
      `gpg-agent --pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh`
 3. Optionally _enable_ persistence of passwords.  
     1. Follow instructions <https://github.com/davotronic5000/PowerShell_Credential_Manager>

--- a/pinentry-wsl-ps1.sh
+++ b/pinentry-wsl-ps1.sh
@@ -15,9 +15,12 @@
 # 1. Save this script and set its permissions to be executable
 # 2. Configure gpg-agent to use this script for pinentry using
 #    one of the following methods:
-#    a) Set pinentry-program within ~/.gnupg/gpg-agent.conf
+#    a) Use `update-alternatives` to change the symlink in `/usr/bin/pinentry`
+#       sudo update-alternatives --install /usr/bin/pinentry pinentry /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh 10
+#       sudo update-alternatives --set pinentry /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh
+#    b) Set pinentry-program within ~/.gnupg/gpg-agent.conf
 #       pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh
-#    b) Set the path to this script when you launch gpg-agent
+#    c) Set the path to this script when you launch gpg-agent
 #       gpg-agent --pinentry-program /mnt/c/repos/pinentry-wsl-ps1/pinentry-wsl-ps1.sh
 # 3. Optionally enable persistence of passwords.
 #    Requires https://github.com/davotronic5000/PowerShell_Credential_Manager


### PR DESCRIPTION
In cases where dotfiles are synchronized across machines (and `gpg-agent.conf` is tracked), modifying the agent options is cumbersome or maybe not even feasible.  
There is a much more machine specific and robust way of changing pinentry though: `update-alternatives`.  
The GnuPG install on Debian based distros uses this anyways (not sure about others though). So it's just a matter of updating the pinentry program we want to use through that.